### PR TITLE
Test: trigger copy transform (workflows 3 & 4)

### DIFF
--- a/agg/java/README.md
+++ b/agg/java/README.md
@@ -1,5 +1,7 @@
 # MongoDB Aggregation Pipeline Study: Java (Sync) Driver
 
+<!-- Test change: exercise copy transform in workflow 3 (agg-java-regex). Timestamp: 2026-04-18 -->
+
 This study will help us learn how you use MongoDB documentation to build aggregation pipelines using the [MongoDB Java (Sync) driver](https://www.mongodb.com/docs/drivers/java/sync/current/).
 
 You’ll work with a subset of the Yelp sample dataset (the `business` and `review` collections) already loaded in MongoDB Atlas. 

--- a/agg/python/README.md
+++ b/agg/python/README.md
@@ -1,5 +1,7 @@
 # MongoDB Aggregation Pipeline Study: PyMongo Driver
 
+<!-- Test change: exercise copy transform in workflow 4 (agg-python-defaults). Timestamp: 2026-04-18 -->
+
 This study will help us learn how you use MongoDB documentation to build aggregation pipelines using the [MongoDB PyMongo driver](https://www.mongodb.com/docs/languages/python/pymongo-driver/current/).
 
 You’ll work with a subset of the Yelp sample dataset (the `business` and `review` collections) already loaded in MongoDB Atlas.


### PR DESCRIPTION
## Test PR for Copier App — Copy Transform

This PR touches files that are listed **only** as `copy:` transform sources in `copier-config.yaml`, to specifically exercise the copy transform path.

| File | Workflow | Transform | Destination |
|------|----------|-----------|-------------|
| `agg/java/README.md` | 3 `agg-java-regex` | `copy` | `cbullinger/copier-app-dest-1` → `java/README.md` |
| `agg/python/README.md` | 4 `agg-python-defaults` | `copy` | `cbullinger/copier-app-dest-2` → `python/README.md` |

### Expected behavior
When merged, the copier app should:
- Workflow 3: open an auto-merge PR to `cbullinger/copier-app-dest-1` with `java/README.md` copied
- Workflow 4: open a default-strategy PR to `cbullinger/copier-app-dest-2` with `python/README.md` copied

No other workflows should activate (no Node.js agg, mflix, or Java source files were touched).